### PR TITLE
:fix:loginWithRedirectエラー対応

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -11,7 +11,7 @@ export default function App({ Component, pageProps }) {
       clientId={process.env['NEXT_PUBLIC_AUTH0_CLIENT_ID']}
       audience={process.env['NEXT_PUBLIC_AUTH0_AUDIENCE']}
       authorizationParams={{
-        redirect_uri: `${process.env['NEXT_PUBLIC_BASE_URL']}`,
+        redirect_uri: `${process.env['NEXT_PUBLIC_BASE_URL']}` || 'http://localhost:9000',
       }}
     >
       <Head>


### PR DESCRIPTION
ログイン時のredirecturiがlocalhostに設定され本番環境でエラーになっていたのでローカルと本番でリダイレクト先を分岐するよう実装