### PR TITLE
:fix:メールアドレス更新後のエラーを修正

### DIFF
--- a/pages/profile/index.jsx
+++ b/pages/profile/index.jsx
@@ -14,7 +14,7 @@ const Profile = () => {
       </div>
     )
   }
-  console.log(user.picture)
+
   if (isAuthenticated) {
     return (
       <div className='flex flex-col sm:w-1/2'>

--- a/pages/profile/updateUserPicture.jsx
+++ b/pages/profile/updateUserPicture.jsx
@@ -58,9 +58,7 @@ const UpdateUserPicture = () => {
         },
       }
       await api.patch(`/users/${user.sub}`, formData, headers)
-      router.push('/profile').then(() => {
-        window.location.reload(true)
-      })
+      router.push('/')
     } catch (err) {
       alert('変更に失敗しました。')
       setLoading(false)


### PR DESCRIPTION
更新成功後に/profileに遷移し再リロードをした際にA client-side exception has occurredのエラーが発生したのでトップページに飛ぶよう修正。コンソールからはエラー原因の詳細は得られなかったが、セッションが切れたあとにuserを 読み込もうとした為かと予想。/profileに飛んだあとリロードをしない場合更新前のメールアドレスが表示されユーザーが困惑するのでトップページに遷移。