### PR TITLE
Feat/add registered shops page

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -120,6 +120,9 @@ export default function PrimarySearchAppBar() {
         <Link href={'/likedReviews'}>いいね済レビュー</Link>
       </MenuItem>
       <MenuItem onClick={handleMenuClose}>
+        <Link href={'/registeredShops'}>登録済店舗</Link>
+      </MenuItem>
+      <MenuItem onClick={handleMenuClose}>
         <Link href={'/shops'}>店舗一覧</Link>
       </MenuItem>
       <MenuItem onClick={handleMenuClose}>
@@ -156,6 +159,9 @@ export default function PrimarySearchAppBar() {
       </MenuItem>
       <MenuItem onClick={handleMenuClose}>
         <Link href={'/likedReviews'}>いいね済レビュー</Link>
+      </MenuItem>
+      <MenuItem onClick={handleMenuClose}>
+        <Link href={'/registeredShops'}>登録済店舗</Link>
       </MenuItem>
       <MenuItem onClick={handleMenuClose}>
         <Link href={'/shops'}>店舗一覧</Link>

--- a/pages/likedReviews.test.js
+++ b/pages/likedReviews.test.js
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { render, waitFor } from '@testing-library/react'
+import { screen, render, waitFor } from '@testing-library/react'
 
 import LikedReviews from './likedReviews'
 import api from '../components/api'
@@ -26,11 +26,11 @@ describe('LikedReviews Component', () => {
     },
   ]
 
-  test('fetches liked reviews data.', async () => {
+  test('calls backend API to fetch data and renders that data.', async () => {
     useAuth0.mockReturnValue({
       isAuthenticated: true,
       getAccessTokenSilently: jest.fn().mockResolvedValue('dummyToken'),
-      isLoading: jest.fn(),
+      isLoading: false,
     })
     await jest.spyOn(api, 'get').mockResolvedValue({ data: likedReviews })
 
@@ -40,6 +40,12 @@ describe('LikedReviews Component', () => {
 
     await waitFor(() => {
       expect(api.get).toHaveBeenCalledWith('/liked_reviews/index', expect.any(Object))
+    })
+
+    await waitFor(() => {
+      likedReviews.forEach((review) => {
+        expect(screen.getByText(review.title)).toBeInTheDocument()
+      })
     })
   })
 })

--- a/pages/myReviews.test.js
+++ b/pages/myReviews.test.js
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react'
-import { render, waitFor } from '@testing-library/react'
+import { screen, render, waitFor } from '@testing-library/react'
 
 import MyReviews from './myReviews'
 import api from '../components/api'
@@ -15,6 +15,9 @@ describe('MyReviews Component', () => {
       image: {
         url: 'https://example.com/review1_thumb.jpg',
       },
+      shop: {
+        name: 'Shop 1',
+      },
     },
     {
       id: 2,
@@ -23,14 +26,17 @@ describe('MyReviews Component', () => {
       image: {
         url: 'https://example.com/review2_thumb.jpg',
       },
+      shop: {
+        name: 'Shop 2',
+      },
     },
   ]
 
-  test('fetches posted reviews data.', async () => {
+  test('calls backend API to fetch data and renders that data.', async () => {
     useAuth0.mockReturnValue({
       isAuthenticated: true,
       getAccessTokenSilently: jest.fn().mockResolvedValue('dummyToken'),
-      isLoading: jest.fn(),
+      isLoading: false,
     })
     await jest.spyOn(api, 'get').mockResolvedValue({ data: postedReviews })
 
@@ -40,6 +46,12 @@ describe('MyReviews Component', () => {
 
     await waitFor(() => {
       expect(api.get).toHaveBeenCalledWith('/my_reviews/index', expect.any(Object))
+    })
+
+    await waitFor(() => {
+      postedReviews.forEach((review) => {
+        expect(screen.getByText(review.title)).toBeInTheDocument()
+      })
     })
   })
 })

--- a/pages/registeredShops.jsx
+++ b/pages/registeredShops.jsx
@@ -1,0 +1,93 @@
+import { useAuth0 } from '@auth0/auth0-react'
+import Box from '@mui/material/Box'
+import Link from 'next/link'
+import { useState, useEffect } from 'react'
+
+import api from '../components/api'
+
+const RegisteredShops = () => {
+  const [token, setToken] = useState('')
+  const [registeredShops, setRegisteredShops] = useState([])
+
+  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0()
+
+  const fetchRegisteredShops = async () => {
+    try {
+      const headers = {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+      const response = await api.get('/registered_shops/index', headers)
+      return response.data
+    } catch (error) {
+      console.error('Error fetching registered shops:', error)
+      return []
+    }
+  }
+
+  useEffect(() => {
+    const getToken = async () => {
+      try {
+        const accessToken = await getAccessTokenSilently({
+          authorizationParams: {
+            audience: `${process.env['NEXT_PUBLIC_AUTH0_AUDIENCE']}`,
+            scope: 'read:current_user',
+          },
+        })
+        setToken(accessToken)
+      } catch (e) {
+        console.log(e.message)
+      }
+    }
+    getToken()
+
+    const getRegisteredShops = async () => {
+      const shops = await fetchRegisteredShops()
+      setRegisteredShops(shops)
+    }
+    getRegisteredShops()
+  }, [token])
+
+  if (isLoading) {
+    return (
+      <div className='flex flex-col sm:w-1/2'>
+        <h2 className='text-4xl'>Loading...</h2>
+      </div>
+    )
+  }
+
+  if (isAuthenticated) {
+    return (
+      <div>
+        <h2 className='mb-8 text-4xl'>登録済店舗</h2>
+        {RegisteredShops.length != 0 ? (
+          <div className='flex flex-col sm:w-1/2'>
+            {RegisteredShops.map((shop) => (
+              <Box className='m-4' key={shop.id}>
+                <Link className='text-xl' href={`/shops/${shop.id}`}>
+                  {shop.name}
+                </Link>
+                <p>{shop.access}</p>
+              </Box>
+            ))}
+          </div>
+        ) : (
+          <div className='flex flex-col'>
+            <p className='mb-8 text-2xl'>ご自身で登録済の店舗がありません。</p>
+          </div>
+        )}
+      </div>
+    )
+  } else {
+    return (
+      <div className='flex flex-col sm:w-1/2'>
+        <div className='mb-8 text-2xl'>
+          ご自身で登録済の店舗を表示するにはログインが必要です。
+        </div>
+      </div>
+    )
+  }
+}
+
+export default RegisteredShops

--- a/pages/registeredShops.jsx
+++ b/pages/registeredShops.jsx
@@ -61,9 +61,9 @@ const RegisteredShops = () => {
     return (
       <div>
         <h2 className='mb-8 text-4xl'>登録済店舗</h2>
-        {RegisteredShops.length != 0 ? (
+        {registeredShops.length != 0 ? (
           <div className='flex flex-col sm:w-1/2'>
-            {RegisteredShops.map((shop) => (
+            {registeredShops.map((shop) => (
               <Box className='m-4' key={shop.id}>
                 <Link className='text-xl' href={`/shops/${shop.id}`}>
                   {shop.name}

--- a/pages/registeredShops.test.js
+++ b/pages/registeredShops.test.js
@@ -1,0 +1,46 @@
+import { useAuth0 } from '@auth0/auth0-react'
+import { screen, render, waitFor } from '@testing-library/react'
+
+import RegisteredShops from './registeredShops'
+import api from '../components/api'
+
+jest.mock('@auth0/auth0-react')
+
+describe('RegisteredShops Component', () => {
+  const registeredShops = [
+    {
+      id: 1,
+      name: 'test 1',
+      access: 'access 1',
+    },
+    {
+      id: 2,
+      name: 'test 2',
+      access: 'access 2',
+    },
+  ]
+
+  test('calls backend API to fetch data and renders that data.', async () => {
+    useAuth0.mockReturnValue({
+      isAuthenticated: true,
+      getAccessTokenSilently: jest.fn().mockResolvedValue('dummyToken'),
+      isLoading: false,
+    })
+    await jest.spyOn(api, 'get').mockResolvedValue({ data: registeredShops })
+
+    await waitFor(() => {
+      render(<RegisteredShops />)
+    })
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/registered_shops/index', expect.any(Object))
+    })
+
+    await waitFor(() => {
+      registeredShops.forEach((shop) => {
+        expect(screen.getByText(shop.name)).toBeInTheDocument()
+        expect(screen.getByText(shop.access)).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/pages/shops/new.jsx
+++ b/pages/shops/new.jsx
@@ -15,7 +15,7 @@ export default function NewShop() {
     name: yup.string().required('店舗名は入力必須項目です。'),
   })
 
-  const { isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0()
+  const { user, isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0()
   const {
     register,
     handleSubmit,
@@ -200,6 +200,7 @@ export default function NewShop() {
               rows={4}
             />
           </Box>
+          <input type='hidden' {...register('sub')} value={user.sub} />
           <CustomizedLoadingButton loading={loading} />
         </form>
       </div>

--- a/pages/shops/new.test.js
+++ b/pages/shops/new.test.js
@@ -19,6 +19,7 @@ const formData = {
   prohibited_matters: '',
   remarks: '',
   when_to_buy_tickets: '',
+  sub: '',
 }
 
 jest.mock('@auth0/auth0-react')


### PR DESCRIPTION
【実装内容】
・自身で登録した店舗のみを表示するregisteredShopsページ実装
・ヘッダーメニューに上記ページへの導線実装
・上記ページのテスト
　・api通信とデータの表示テスト
・上記ページに似た実装のmyReviews, likedReviewsページのテストも合わせて修正
　・api通信のみのものにデータの表示テストも追加
・shops/new.test.jsもデータにsubを含むよう修正
