### PR TITLE
:update:エラー発生時にローディングボタンを止める

### DIFF
--- a/pages/shops/[shopId]/edit.jsx
+++ b/pages/shops/[shopId]/edit.jsx
@@ -64,6 +64,7 @@ export default function EditShop({ shop }) {
       await api.patch(`/shops/${shopId}`, data, headers)
       router.push('/')
     } catch (err) {
+      setLoading(false)
       alert('登録に失敗しました。')
     }
   }

--- a/pages/shops/[shopId]/reviews/[reviewId]/edit.jsx
+++ b/pages/shops/[shopId]/reviews/[reviewId]/edit.jsx
@@ -74,8 +74,8 @@ export default function EditReview({ review }) {
       await api.patch(`/shops/${shopId}/reviews/${reviewId}`, formData, headers)
       router.push('/')
     } catch (err) {
+      setLoading(false)
       alert('登録に失敗しました。')
-      console.log(data)
     }
   }
 

--- a/pages/shops/[shopId]/reviews/new.jsx
+++ b/pages/shops/[shopId]/reviews/new.jsx
@@ -66,6 +66,7 @@ export default function NewReview() {
       await api.post(`/shops/${shopId}/reviews`, formData, headers)
       router.push('/')
     } catch (err) {
+      setLoading(false)
       alert('登録に失敗しました。')
     }
   }

--- a/pages/shops/new.jsx
+++ b/pages/shops/new.jsx
@@ -53,6 +53,7 @@ export default function NewShop() {
       await api.post('/shops', data, headers)
       router.push('/')
     } catch (err) {
+      setLoading(false)
       alert('登録に失敗しました。')
     }
   }


### PR DESCRIPTION
エラー発生時にloadingをfalseにしないと再度ボタンが押せずにユーザーはページをリロードするしかなく、それではUX的に良くない為