### PR TITLE
:update:データが正常にfetchされるまでloadingを表示する

### DIFF
--- a/pages/likedReviews.jsx
+++ b/pages/likedReviews.jsx
@@ -9,7 +9,7 @@ import api from '../components/api'
 
 const LikedReviews = () => {
   const [token, setToken] = useState('')
-  const [likedReviews, setLikedReviews] = useState([])
+  const [likedReviews, setLikedReviews] = useState(null)
 
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0()
 
@@ -24,7 +24,7 @@ const LikedReviews = () => {
       return response.data
     } catch (error) {
       console.error('Error fetching liked reviews:', error)
-      return []
+      return null
     }
   }
 
@@ -60,47 +60,55 @@ const LikedReviews = () => {
   }
 
   if (isAuthenticated) {
-    return (
-      <div>
-        <h2 className='mb-8 text-4xl'>いいね済レビュー</h2>
-        {likedReviews.length != 0 ? (
-          <div className='flex flex-col'>
-            {likedReviews.map((review) => (
-              <Box className='m-4 flex' key={review.id}>
-                <div className='mr-10'>
-                  <Image
-                    src={review.image.url}
-                    alt='reviewImage'
-                    className='rounded-lg'
-                    width={200}
-                    height={150}
-                    priority
-                    unoptimized
-                  />
-                </div>
-                <div>
-                  <Link
-                    className='text-xl'
-                    href={`/shops/${review.shop_id}/reviews/${review.id}`}
-                  >
-                    {review.title}
-                  </Link>
-                  <p className='mt-4 text-lg'>評価：{review.score} / 5</p>
-                  <p className='mt-4 text-lg'>
-                    投稿日：{moment(review.created_at).format('YYYY-MM-DD')}
-                  </p>
-                  <p className='mt-2 text-lg'>店舗名：{review.shop.name}</p>
-                </div>
-              </Box>
-            ))}
-          </div>
-        ) : (
-          <div className='flex flex-col'>
-            <p className='mb-8 text-2xl'>いいね済のレビューがありません。</p>
-          </div>
-        )}
-      </div>
-    )
+    if (likedReviews != null) {
+      return (
+        <div>
+          <h2 className='mb-8 text-4xl'>いいね済レビュー</h2>
+          {likedReviews.length != 0 ? (
+            <div className='flex flex-col'>
+              {likedReviews.map((review) => (
+                <Box className='m-4 flex' key={review.id}>
+                  <div className='mr-10'>
+                    <Image
+                      src={review.image.url}
+                      alt='reviewImage'
+                      className='rounded-lg'
+                      width={200}
+                      height={150}
+                      priority
+                      unoptimized
+                    />
+                  </div>
+                  <div>
+                    <Link
+                      className='text-xl'
+                      href={`/shops/${review.shop_id}/reviews/${review.id}`}
+                    >
+                      {review.title}
+                    </Link>
+                    <p className='mt-4 text-lg'>評価：{review.score} / 5</p>
+                    <p className='mt-4 text-lg'>
+                      投稿日：{moment(review.created_at).format('YYYY-MM-DD')}
+                    </p>
+                    <p className='mt-2 text-lg'>店舗名：{review.shop.name}</p>
+                  </div>
+                </Box>
+              ))}
+            </div>
+          ) : (
+            <div className='flex flex-col'>
+              <p className='mb-8 text-2xl'>いいね済のレビューがありません。</p>
+            </div>
+          )}
+        </div>
+      )
+    } else {
+      return (
+        <div className='flex flex-col sm:w-1/2'>
+          <h2 className='text-4xl'>Loading...</h2>
+        </div>
+      )
+    }
   } else {
     return (
       <div className='flex flex-col sm:w-1/2'>

--- a/pages/myReviews.jsx
+++ b/pages/myReviews.jsx
@@ -9,7 +9,7 @@ import api from '../components/api'
 
 const MyReviews = () => {
   const [token, setToken] = useState('')
-  const [myReviews, setMyReviews] = useState([])
+  const [myReviews, setMyReviews] = useState(null)
 
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0()
 
@@ -24,7 +24,7 @@ const MyReviews = () => {
       return response.data
     } catch (error) {
       console.error('Error fetching posted reviews:', error)
-      return []
+      return null
     }
   }
 
@@ -60,47 +60,55 @@ const MyReviews = () => {
   }
 
   if (isAuthenticated) {
-    return (
-      <div>
-        <h2 className='mb-8 text-4xl'>投稿済レビュー</h2>
-        {myReviews.length != 0 ? (
-          <div className='flex flex-col'>
-            {myReviews.map((review) => (
-              <Box className='m-4 flex' key={review.id}>
-                <div className='mr-10'>
-                  <Image
-                    src={review.image.url}
-                    alt='reviewImage'
-                    className='rounded-lg'
-                    width={200}
-                    height={150}
-                    priority
-                    unoptimized
-                  />
-                </div>
-                <div>
-                  <Link
-                    className='text-xl'
-                    href={`/shops/${review.shop_id}/reviews/${review.id}`}
-                  >
-                    {review.title}
-                  </Link>
-                  <p className='mt-2 text-lg'>評価：{review.score} / 5</p>
-                  <p className='mt-2 text-lg'>
-                    投稿日：{moment(review.created_at).format('YYYY-MM-DD')}
-                  </p>
-                  <p className='mt-2 text-lg'>店舗名：{review.shop.name}</p>
-                </div>
-              </Box>
-            ))}
-          </div>
-        ) : (
-          <div className='flex flex-col'>
-            <p className='mb-8 text-2xl'>投稿済レビューがありません。</p>
-          </div>
-        )}
-      </div>
-    )
+    if (myReviews != null) {
+      return (
+        <div>
+          <h2 className='mb-8 text-4xl'>投稿済レビュー</h2>
+          {myReviews.length != 0 ? (
+            <div className='flex flex-col'>
+              {myReviews.map((review) => (
+                <Box className='m-4 flex' key={review.id}>
+                  <div className='mr-10'>
+                    <Image
+                      src={review.image.url}
+                      alt='reviewImage'
+                      className='rounded-lg'
+                      width={200}
+                      height={150}
+                      priority
+                      unoptimized
+                    />
+                  </div>
+                  <div>
+                    <Link
+                      className='text-xl'
+                      href={`/shops/${review.shop_id}/reviews/${review.id}`}
+                    >
+                      {review.title}
+                    </Link>
+                    <p className='mt-2 text-lg'>評価：{review.score} / 5</p>
+                    <p className='mt-2 text-lg'>
+                      投稿日：{moment(review.created_at).format('YYYY-MM-DD')}
+                    </p>
+                    <p className='mt-2 text-lg'>店舗名：{review.shop.name}</p>
+                  </div>
+                </Box>
+              ))}
+            </div>
+          ) : (
+            <div className='flex flex-col'>
+              <p className='mb-8 text-2xl'>投稿済レビューがありません。</p>
+            </div>
+          )}
+        </div>
+      )
+    } else {
+      return (
+        <div className='flex flex-col sm:w-1/2'>
+          <h2 className='text-4xl'>Loading...</h2>
+        </div>
+      )
+    }
   } else {
     return (
       <div className='flex flex-col sm:w-1/2'>

--- a/pages/registeredShops.jsx
+++ b/pages/registeredShops.jsx
@@ -7,7 +7,7 @@ import api from '../components/api'
 
 const RegisteredShops = () => {
   const [token, setToken] = useState('')
-  const [registeredShops, setRegisteredShops] = useState([])
+  const [registeredShops, setRegisteredShops] = useState(null)
 
   const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0()
 
@@ -22,7 +22,7 @@ const RegisteredShops = () => {
       return response.data
     } catch (error) {
       console.error('Error fetching registered shops:', error)
-      return []
+      return null
     }
   }
 
@@ -58,27 +58,35 @@ const RegisteredShops = () => {
   }
 
   if (isAuthenticated) {
-    return (
-      <div>
-        <h2 className='mb-8 text-4xl'>登録済店舗</h2>
-        {registeredShops.length != 0 ? (
-          <div className='flex flex-col'>
-            {registeredShops.map((shop) => (
-              <Box className='m-4' key={shop.id}>
-                <Link className='text-xl' href={`/shops/${shop.id}`}>
-                  {shop.name}
-                </Link>
-                <p>{shop.access}</p>
-              </Box>
-            ))}
-          </div>
-        ) : (
-          <div className='flex flex-col'>
-            <p className='mb-8 text-2xl'>ご自身で登録済の店舗がありません。</p>
-          </div>
-        )}
-      </div>
-    )
+    if (registeredShops != null) {
+      return (
+        <div>
+          <h2 className='mb-8 text-4xl'>登録済店舗</h2>
+          {registeredShops.length != 0 ? (
+            <div className='flex flex-col'>
+              {registeredShops.map((shop) => (
+                <Box className='m-4' key={shop.id}>
+                  <Link className='text-xl' href={`/shops/${shop.id}`}>
+                    {shop.name}
+                  </Link>
+                  <p>{shop.access}</p>
+                </Box>
+              ))}
+            </div>
+          ) : (
+            <div className='flex flex-col'>
+              <p className='mb-8 text-2xl'>ご自身で登録済の店舗がありません。</p>
+            </div>
+          )}
+        </div>
+      )
+    } else {
+      return (
+        <div className='flex flex-col sm:w-1/2'>
+          <h2 className='text-4xl'>Loading...</h2>
+        </div>
+      )
+    }
   } else {
     return (
       <div className='flex flex-col'>


### PR DESCRIPTION
今回修正した類似しているこの3ファイルでは、tokenが正常にセットされる前にデータフェッチが走ってしまい一度401エラーが起こりデータの取得に失敗するのだが、その際に空の配列を戻り値として設定していた為データのlength == 0と判断され、本当はデータがある場合にも少しの間「〜はありません」との趣旨の画面がレンダーされてしまいユーザーに混乱を与える実装になっていた為、代わりにnullを返すように修正し、nullの限りはloadingを表示するように実装