### PR TITLE
店舗一覧ページのパフォーマンス改善 

### DIFF
--- a/pages/shops/index.jsx
+++ b/pages/shops/index.jsx
@@ -8,7 +8,7 @@ export default function IndexShops() {
   const [loading, setLoading] = useState(true)
   const [shops, setShops] = useState(null)
 
-  const fetchRegisteredShops = async () => {
+  const fetchShops = async () => {
     try {
       const response = await api.get('/shops')
       return response.data
@@ -20,7 +20,7 @@ export default function IndexShops() {
 
   useEffect(() => {
     const getShops = async () => {
-      const shopsData = await fetchRegisteredShops()
+      const shopsData = await fetchShops()
       setShops(shopsData)
       setLoading(false)
     }

--- a/pages/shops/index.jsx
+++ b/pages/shops/index.jsx
@@ -1,27 +1,55 @@
-import { Box } from '@mui/material'
+import { Box, CircularProgress } from '@mui/material'
 import Link from 'next/link'
+import { useState, useEffect } from 'react'
 
 import api from '../../components/api'
 
-export async function getServerSideProps() {
-  const res = await api.get('/shops')
-  const shops = res.data
-  return {
-    props: { shops: shops },
-  }
-}
+export default function IndexShops() {
+  const [loading, setLoading] = useState(true)
+  const [shops, setShops] = useState(null)
 
-export default function IndexShops({ shops }) {
+  const fetchRegisteredShops = async () => {
+    try {
+      const response = await api.get('/shops')
+      return response.data
+    } catch (error) {
+      console.error('Error fetching shops:', error)
+      return null
+    }
+  }
+
+  useEffect(() => {
+    const getShops = async () => {
+      const shopsData = await fetchRegisteredShops()
+      setShops(shopsData)
+      setLoading(false)
+    }
+    getShops()
+  }, [])
+
   return (
-    <div className='flex flex-col sm:w-1/2'>
-      {shops.map((shop) => (
-        <Box className='m-4' key={shop.id}>
-          <Link className='text-xl' href={`/shops/${shop.id}`}>
-            {shop.name}
-          </Link>
-          <p>{shop.access}</p>
-        </Box>
-      ))}
+    <div>
+      {loading ? (
+        <div className='flex items-center'>
+          <h2 className='text-4xl'>
+            Loading
+            <span className='ml-4'>
+              <CircularProgress />
+            </span>
+          </h2>
+        </div>
+      ) : (
+        <div className='flex flex-col'>
+          {shops.map((shop) => (
+            <Box className='m-4' key={shop.id}>
+              <Link className='text-xl' href={`/shops/${shop.id}`}>
+                {shop.name}
+              </Link>
+              <p>{shop.access}</p>
+            </Box>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
getServerSidePropsでデータを取得していたが、取得までに数秒かかる場合があり、その際ページ遷移せずに何の動きもなく待たされてしまっていた為、フロント側でデータ取得を行いデータ準備完了まではloadingを表示させることでUXの向上につながるよう修正